### PR TITLE
fix Read/Write func offset advancement

### DIFF
--- a/pipeat.go
+++ b/pipeat.go
@@ -247,7 +247,7 @@ func (r *PipeReaderAt) ReadAt(p []byte, off int64) (int, error) {
 func (r *PipeReaderAt) Read(p []byte) (int, error) {
 	trace("read", len(p))
 	n, err := r.ReadAt(p, r.f.readeroff)
-	if err == nil {
+	if n > 0 {
 		r.f.dataLock.Lock()
 		defer r.f.dataLock.Unlock()
 		r.f.readeroff = r.f.readeroff + int64(n)
@@ -334,7 +334,7 @@ func (w *PipeWriterAt) Write(p []byte) (int, error) {
 	defer w.f.fileLock.RUnlock()
 	n, err := w.f.Write(p)
 	w.f.updateWrittenBytes(n)
-	if err == nil {
+	if n > 0 {
 		w.f.dataLock.Lock()
 		defer w.f.dataLock.Unlock()
 		w.f.endln += int64(n)

--- a/pipeat.go
+++ b/pipeat.go
@@ -247,7 +247,7 @@ func (r *PipeReaderAt) ReadAt(p []byte, off int64) (int, error) {
 func (r *PipeReaderAt) Read(p []byte) (int, error) {
 	trace("read", len(p))
 	n, err := r.ReadAt(p, r.f.readeroff)
-	if n > 0 {
+	if err == nil || (err == io.EOF && n > 0) {
 		r.f.dataLock.Lock()
 		defer r.f.dataLock.Unlock()
 		r.f.readeroff = r.f.readeroff + int64(n)
@@ -334,7 +334,7 @@ func (w *PipeWriterAt) Write(p []byte) (int, error) {
 	defer w.f.fileLock.RUnlock()
 	n, err := w.f.Write(p)
 	w.f.updateWrittenBytes(n)
-	if n > 0 {
+	if err == nil {
 		w.f.dataLock.Lock()
 		defer w.f.dataLock.Unlock()
 		w.f.endln += int64(n)

--- a/pipeat_test.go
+++ b/pipeat_test.go
@@ -336,8 +336,10 @@ func TestIoRead(t *testing.T) {
 	go ccWriter(t, w, workers)
 	w.WaitForReader()
 	assert.Equal(t, reader.String(), paragraph)
-	assert.Equal(t, r.GetReadedBytes(), int64(len(paragraph)))
-	assert.Equal(t, w.GetWrittenBytes(), int64(len(paragraph)))
+	assert.Equal(t, int64(len(paragraph)), r.GetReadedBytes())
+	assert.Equal(t, int64(len(paragraph)), w.GetWrittenBytes())
+	assert.Equal(t, int64(len(paragraph)), r.f.readeroff)
+	assert.Equal(t, int64(len(paragraph)), r.f.endln)
 }
 
 // io.Writer paired wit concurrent reader


### PR DESCRIPTION
A read operation can a positive number of bytes read and `io.EOF`. The `err == nil` check in the `Read` function caused an endless read loop re-reading the last few bytes because the ReadAt function returned an io.EOF, but the reader offset was not advanced.